### PR TITLE
Fixed issue with http_proxy_hostname for java

### DIFF
--- a/templates/etc/profile.d/java-proxyenv.sh.j2
+++ b/templates/etc/profile.d/java-proxyenv.sh.j2
@@ -1,9 +1,15 @@
 {% if proxy_env is defined %}
 {% if proxy_env.http_proxy is defined %}
-export JAVA_OPTS="$JAVA_OPTS -Dhttp.proxyHost={{http_proxy_hostname}} -Dhttp.proxyPort={{http_proxy_port}}"
+PROXY_HTTP_HOST_AND_PORT=`basename {{proxy_env.http_proxy}}`
+PROXY_HTTP_HOST=`basename {{proxy_env.http_proxy}} | cut -d ":" -f 1`
+PROXY_HTTP_PORT=`basename {{proxy_env.http_proxy}} | cut -d ":" -f 2`
+export JAVA_OPTS="$JAVA_OPTS -Dhttp.proxyHost=$PROXY_HTTP_HOST -Dhttp.proxyPort=$PROXY_HTTP_PORT"
 {% endif %}
 {% if proxy_env.https_proxy is defined %}
-export JAVA_OPTS="$JAVA_OPTS -Dhttps.proxyHost={{https_proxy_hostname}} -Dhttps.proxyPort={{https_proxy_port}}"
+PROXY_HTTPS_HOST_AND_PORT=`basename {{proxy_env.https_proxy}}`
+PROXY_HTTPS_HOST=`basename {{proxy_env.https_proxy}} | cut -d ":" -f 1`
+PROXY_HTTPS_PORT=`basename {{proxy_env.https_proxy}} | cut -d ":" -f 2`
+export JAVA_OPTS="$JAVA_OPTS -Dhttps.proxyHost=$PROXY_HTTPS_HOST -Dhttps.proxyPort=$PROXY_HTTPS_PORT"
 {% endif %}
 {% if proxy_env.no_proxy is defined %}
 export JAVA_OPTS="$JAVA_OPTS -DnoProxyHosts={{proxy_env.no_proxy}}"


### PR DESCRIPTION
Without this fix, I get this when I try and run the module:

    fatal: [daxperf10] => {'msg': "AnsibleUndefinedVariable: One or more
    undefined variables: 'http_proxy_hostname' is undefined", 'failed': True}

You can workaround by setting that variable outside of proxy_env, but this
fix should allow you to derive the host and port names from the existing
http_proxy and https_proxy members of proxy_env.